### PR TITLE
Untitled

### DIFF
--- a/pwm.c
+++ b/pwm.c
@@ -269,6 +269,8 @@ void update_brightness(void) {
 			if (global_pwm.channels[i].brightness == global_pwm.channels[i].target_brightness) {
 				global_pwm.channels[i].flags.target_reached = 1;
 			}
+		} else {
+			global_pwm.channels[i].flags.target_reached = 1;
 		}
 	}
 }


### PR DESCRIPTION
Set target_reached flag whenever brightness and target_brightness are equal. We waste one CPU cycle, but we can be sure that the target_reached flag is always set.
